### PR TITLE
Expand default-directory in dired-toggle-sidebar

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -546,7 +546,8 @@ With universal argument, use current directory."
     (let* ((old-buffer (dired-sidebar-buffer (selected-frame)))
            (file-to-show (dired-sidebar-get-file-to-show))
            (dir-to-show (or dir
-                            (when current-prefix-arg default-directory)
+                            (when current-prefix-arg
+                              (expand-file-name default-directory))
                             (dired-sidebar-get-dir-to-show)))
            (sidebar-buffer (dired-sidebar-get-or-create-buffer dir-to-show)))
       (dired-sidebar-show-sidebar sidebar-buffer)


### PR DESCRIPTION
Without this, dired-sidebar-point-at-file throws an error when default-directory
uses ~ for the user directory