### PR TITLE
Reference dired-sidebar-face as a face

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -850,7 +850,7 @@ the relevant file-directory clicked on by the mouse."
 
 Set font to a variable width (proportional) in the current buffer."
   (interactive)
-  (setq-local buffer-face-mode-face dired-sidebar-face)
+  (setq-local buffer-face-mode-face 'dired-sidebar-face)
   (buffer-face-mode))
 
 (defun dired-sidebar-set-mode-line ()


### PR DESCRIPTION
Fixes #69 

Since the face is no longer a variable, it needs to be referenced in quoted form. (This is the only place it was used.)