### PR TITLE
feat: add options dired-sidebar-window-fixed and dired-sidebar-resize-open

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -106,8 +106,18 @@ This only takes effect if on a local connection. (e.g. Not Tramp)"
                  (const vscode)))
 
 (defcustom dired-sidebar-width 35
-  "Width of the `dired-sidebar' buffer."
+  "Width of the `dired-sidebar' buffer.
+This option does not have effect if `dired-sidebar-resize-on-open' is nil.
+If you set `dired-sidebar-resize-on-open' to nil, you can customize `dired-sidebar-display-alist'
+to control the width anyway."
   :type 'integer
+  :group 'dired-sidebar)
+
+(defcustom dired-sidebar-window-fixed 'width
+  "Whether the width or height of the sidebar window should be fixed (to prevent from resizing)."
+  :type '(choice (const nil)
+                 (const width)
+                 (const height))
   :group 'dired-sidebar)
 
 (defcustom dired-sidebar-refresh-on-project-switch t
@@ -261,6 +271,11 @@ with a prefix arg or when `dired-sidebar-find-file-alt' is called."
   :type 'boolean
   :group 'dired-sidebar)
 
+(defcustom dired-sidebar-resize-on-open t
+  "When dired sidebar window is showed, automatically adjust its width according to `dired-sidebar-width'"
+  :type 'boolean
+  :group 'dired-sidebar)
+
 (defcustom dired-sidebar-recenter-cursor-on-tui-update nil
   "Whether or not to center cursor when updating tui interface."
   :type 'boolean
@@ -411,7 +426,7 @@ Works around marker pointing to wrong buffer in Emacs 25."
     (advice-add 'wdired-change-to-wdired-mode
                 :around 'dired-sidebar-wdired-change-to-wdired-mode-advice))
 
-  (setq window-size-fixed 'width)
+  (setq window-size-fixed dired-sidebar-window-fixed)
 
   ;; Match backgrounds.
   (setq-local dired-subtree-use-backgrounds nil)
@@ -654,9 +669,10 @@ This is dependent on `dired-subtree-cycle'."
       (when dired-sidebar-no-delete-other-windows
         (set-window-parameter window 'no-delete-other-windows t))
       (set-window-dedicated-p window t)
-      (with-selected-window window
-        (let ((window-size-fixed))
-          (dired-sidebar-set-width dired-sidebar-width))))
+      (when dired-sidebar-resize-on-open
+        (with-selected-window window
+          (let ((window-size-fixed))
+            (dired-sidebar-set-width dired-sidebar-width)))))
     (with-current-buffer buffer
       (if (eq major-mode 'dired-sidebar-mode)
           (dired-build-subdir-alist)


### PR DESCRIPTION
I personally would love to configure all of my windows via the setting `dired-sidebar-window-display-alist`. And sometimes I want to drag the window to see more/less content of the sidebar.

Setting the window as a fixed window and automatically resize the width of the window disobeys the above wishes. Providing the two options in this commit would allow a more flexible way to customize the sidebar window by the user.

I personally use the following configs to allow the window width to be always `20%` of my main window.

```lisp
(use-package dired-siderbar
    :init
    (setq dired-sidebar-display-alist '((window-width . 0.2)
                                        (side . left)
                                        (slot . -1))
          dired-sidebar-resize-on-open nil
          dired-sidebar-window-fixed nil))

```