### PR TITLE
Fix icons align with nerd fonts.

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -1145,7 +1145,7 @@ after."
                         (if (dired-subtree--is-expanded-p)
                             (insert (concat collapsible-icon " "))
                           (insert (concat expandable-icon " ")))
-                      (insert "")))))))
+                      (insert (if (eq dired-sidebar-theme 'nerd) "  " ""))))))))
           (forward-line 1))))))
 
 (defun dired-sidebar-tui-update-with-delay (&rest _)


### PR DESCRIPTION
The file icons is not aligned with the directory icon when use nerd fonts with:

(setq dired-sidebar-theme 'nerd).

Alignment before:

![imagen](https://github.com/jojojames/dired-sidebar/assets/8014685/dbc3467f-2699-472d-8c73-966f4a2172c7)

Alignment with the fix:

![imagen](https://github.com/jojojames/dired-sidebar/assets/8014685/8d2d36c2-6056-4875-b122-a20d50e1b2b1)

