### PR TITLE
Resolving issue with modification dates produced by ls.

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -611,7 +611,9 @@ This is dependent on `dired-subtree-cycle'."
              (dirs (when (cadr (split-string name root))
                      (split-string (cadr (split-string name root)) "/"))))
         (dolist (dir dirs)
-          (let ((path-regex (concat "^.*[[:space:]]" (regexp-quote dir))))
+          ;; Trailing `$' is essential to avoid matching the modification date
+          ;; fields of the underlying `ls' process
+          (let ((path-regex (concat "^.*[[:space:]]" (regexp-quote dir) "$")))
             (setq path (concat path dir))
             (if (file-regular-p path)
                 ;; Try to use `dired-goto-file' to go to the correct


### PR DESCRIPTION
I encountered an issue with folders named "2022", etc.

After closer investigation, it turned out that the regular expression was actually matching the modification year in the output of `ls'. By adding a `$' at the end of the regular expression, this issue was resolved.

Been using the modified version for a couple of months, and did not encounter any obvious side-effects.