### PR TITLE
Update dired-sidebar.el to use the face as a symbol

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -882,7 +882,7 @@ the relevant file-directory clicked on by the mouse."
 
 Set font to a variable width (proportional) in the current buffer."
   (interactive)
-  (setq-local buffer-face-mode-face dired-sidebar-face)
+  (setq-local buffer-face-mode-face 'dired-sidebar-face)
   (buffer-face-mode))
 
 (defun dired-sidebar-set-mode-line ()


### PR DESCRIPTION
Having `(setq dired-sidebar-use-custom-font t)`

Makes the side `dired-sidebar-set-font` function to throw this error:
```
dired-sidebar-set-font: Symbol’s value as variable is void: dired-sidebar-face
```

Fixes:
- https://github.com/jojojames/dired-sidebar/issues/89

I believe this bug was introduced in:
- https://github.com/jojojames/dired-sidebar/issues/81


## Test

```emacs-lisp
  (setq dired-sidebar-use-custom-font t)
  (set-face-attribute 'dired-sidebar-face nil :height 0.8)
```
<img width="306" alt="image" src="https://github.com/jojojames/dired-sidebar/assets/950087/f0cca226-8431-4975-acdf-0e7f2c72bbe5">
