### PR TITLE
Allow for trailing slash at end of directory name

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -614,7 +614,7 @@ This is dependent on `dired-subtree-cycle'."
         (dolist (dir dirs)
           ;; Trailing `$' is essential to avoid matching the modification date
           ;; fields of the underlying `ls' process
-          (let ((path-regex (concat "^.*[[:space:]]" (regexp-quote dir) "$")))
+          (let ((path-regex (concat "^.*[[:space:]]" (regexp-quote dir) "\/?$")))
             (setq path (concat path dir))
             (if (file-regular-p path)
                 ;; Try to use `dired-goto-file' to go to the correct


### PR DESCRIPTION
`ls` (at least, the GNU implementation of it) has a `classify` option (and `file-type` as well), that prints a specific character at the end of the filename :

```
       -F, --classify[=WHEN]
              append indicator (one of */=>@|) to entries WHEN

       --file-type
              likewise, except do not append '*'
```

The regex in the function `dired-sidebar-point-at-file` does not account for this possibility.

In this case, `dir` is a directory, so the only possible character is `/`. The PR simply modifies the regex to allow this character.

I've just happened on a similar error as mentioned in #33, and the regex being too restrictive is the cause.

Best,

Aymeric