### PR TITLE
Add an option to resize the frame when showing or hiding the sidebar

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -686,8 +686,9 @@ This is dependent on `dired-subtree-cycle'."
             (dired-sidebar-set-width dired-sidebar-width))))
       (when dired-sidebar-adjust-frame-width
         (let ((frame (window-frame window)))
-          (set-frame-width frame (+ (frame-width frame)
-                                    (window-total-width window))))))
+          (unless (frame-parameter frame 'fullscreen)
+            (set-frame-width frame (+ (frame-width frame)
+                                      (window-total-width window)))))))
     (with-current-buffer buffer
       (if (eq major-mode 'dired-sidebar-mode)
           (dired-build-subdir-alist)
@@ -701,8 +702,9 @@ This is dependent on `dired-subtree-cycle'."
               (window (get-buffer-window buffer)))
     (when dired-sidebar-adjust-frame-width
         (let ((frame (window-frame window)))
-          (set-frame-width frame (- (frame-width frame)
-                                    (window-total-width window)))))
+          (unless (frame-parameter frame 'fullscreen)
+            (set-frame-width frame (- (frame-width frame)
+                                      (window-total-width window))))))
     (delete-window window)))
 
 ;;;###autoload

--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -339,6 +339,14 @@ See https://github.com/jojojames/dired-sidebar/issues/43."
   :type 'list
   :group 'dired-sidebar)
 
+(defcustom dired-sidebar-adjust-frame-width nil
+  "Whether or not to change the frame size when showing and hiding the sidebar.
+
+This has other windows retain their size."
+  :type 'boolean
+  :group 'dired-sidebar
+  )
+
 ;; Internal
 
 (defvar-local dired-sidebar-stale-buffer-timer nil
@@ -675,7 +683,11 @@ This is dependent on `dired-subtree-cycle'."
       (when dired-sidebar-resize-on-open
         (with-selected-window window
           (let ((window-size-fixed))
-            (dired-sidebar-set-width dired-sidebar-width)))))
+            (dired-sidebar-set-width dired-sidebar-width))))
+      (when dired-sidebar-adjust-frame-width
+        (let ((frame (window-frame window)))
+          (set-frame-width frame (+ (frame-width frame)
+                                    (window-total-width window))))))
     (with-current-buffer buffer
       (if (eq major-mode 'dired-sidebar-mode)
           (dired-build-subdir-alist)
@@ -685,8 +697,13 @@ This is dependent on `dired-subtree-cycle'."
 (defun dired-sidebar-hide-sidebar ()
   "Hide the sidebar in the selected frame."
   (interactive)
-  (when-let* ((buffer (dired-sidebar-buffer)))
-    (delete-window (get-buffer-window buffer))))
+  (when-let* ((buffer (dired-sidebar-buffer))
+              (window (get-buffer-window buffer)))
+    (when dired-sidebar-adjust-frame-width
+        (let ((frame (window-frame window)))
+          (set-frame-width frame (- (frame-width frame)
+                                    (window-total-width window)))))
+    (delete-window window)))
 
 ;;;###autoload
 (defun dired-sidebar-jump-to-sidebar ()

--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -344,8 +344,7 @@ See https://github.com/jojojames/dired-sidebar/issues/43."
 
 This has other windows retain their size."
   :type 'boolean
-  :group 'dired-sidebar
-  )
+  :group 'dired-sidebar)
 
 ;; Internal
 
@@ -667,6 +666,16 @@ This is dependent on `dired-subtree-cycle'."
   (let ((current-prefix-arg '(4))) ; C-u
     (call-interactively #'dired-sidebar-toggle-sidebar)))
 
+(defun dired-sidebar-maybe-adjust-frame-width (window &optional dec)
+  "If needed, increase (or decrease, if DEC is non-nil) the enclosing 
+frame width to accomodate for the sidebar."  
+  (when dired-sidebar-adjust-frame-width
+    (let ((frame (window-frame window)))
+      (unless (frame-parameter frame 'fullscreen)
+        (set-frame-width frame (funcall (if dec '- '+)
+                                        (frame-width frame)
+                                        (window-total-width window)))))))  
+
 ;;;###autoload
 (defun dired-sidebar-show-sidebar (&optional b)
   "Show sidebar displaying buffer B."
@@ -684,11 +693,7 @@ This is dependent on `dired-subtree-cycle'."
         (with-selected-window window
           (let ((window-size-fixed))
             (dired-sidebar-set-width dired-sidebar-width))))
-      (when dired-sidebar-adjust-frame-width
-        (let ((frame (window-frame window)))
-          (unless (frame-parameter frame 'fullscreen)
-            (set-frame-width frame (+ (frame-width frame)
-                                      (window-total-width window)))))))
+      (dired-sidebar-maybe-adjust-frame-width window))
     (with-current-buffer buffer
       (if (eq major-mode 'dired-sidebar-mode)
           (dired-build-subdir-alist)
@@ -700,11 +705,7 @@ This is dependent on `dired-subtree-cycle'."
   (interactive)
   (when-let* ((buffer (dired-sidebar-buffer))
               (window (get-buffer-window buffer)))
-    (when dired-sidebar-adjust-frame-width
-        (let ((frame (window-frame window)))
-          (unless (frame-parameter frame 'fullscreen)
-            (set-frame-width frame (- (frame-width frame)
-                                      (window-total-width window))))))
+    (dired-sidebar-maybe-adjust-frame-width window t)         
     (delete-window window)))
 
 ;;;###autoload


### PR DESCRIPTION
I want to keep the size of my other windows fixed when toggling the sidebar.

I don't know if this is anybody's else cup of tea, but just in case it is, this PR adds that functionality: 

- Introduce a new custom var, `dired-sidebar-adjust-frame-width`.
- Make `dired-sidebar-show-sidebar` and `dired-sidebar-hide-sidebar` increase or decrease the frame width by the sidebar width when that new custom variable value is true.