### PR TITLE
Fix multiple build and test failures 

### DIFF
--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -1035,7 +1035,7 @@ This is somewhat experimental/hacky."
           (term-previous-prompt 1))
         (when (fboundp 'term-simple-send)
           (term-simple-send (get-buffer-process (current-buffer)) "pwd"))
-        (sleep-for 0 50)
+        (sleep-for 0.05)
         (forward-line 1)
         (let ((result (string-trim (thing-at-point 'line))))
           (kill-whole-line)

--- a/dired-sidebar.el
+++ b/dired-sidebar.el
@@ -73,7 +73,7 @@ This uses format specified by `dired-sidebar-mode-line-format'."
     mode-line-buffer-identification
     " "  mode-line-end-spaces)
   "Mode line format for `dired-sidebar'."
-  :type 'list
+  :type 'sexp
   :group 'dired-sidebar)
 
 (defcustom dired-sidebar-theme 'icons
@@ -241,7 +241,7 @@ to wait to refresh the sidebar after the CAR of the alist is called.
 
 Set this to nil or set `dired-sidebar-refresh-on-special-commands' to nil
 to disable automatic refresh when a special command is triggered."
-  :type 'list
+  :type '(repeat (choice symbol (cons symbol integer)))
   :group 'dired-sidebar)
 
 (defcustom dired-sidebar-toggle-hidden-commands
@@ -254,7 +254,7 @@ command is completed.
 This functionality is implemented using advice.
 
 Set this to nil to disable this advice."
-  :type 'list
+  :type 'hook
   :group 'dired-sidebar)
 
 (defcustom dired-sidebar-alternate-select-window-function
@@ -336,7 +336,7 @@ For more information, look up `delete-other-windows'."
   "List of modes in `dired-mode-hook' that prevents icon display.
 
 See https://github.com/jojojames/dired-sidebar/issues/43."
-  :type 'list
+  :type 'hook
   :group 'dired-sidebar)
 
 ;; Internal

--- a/test/dired-sidebar-test.el
+++ b/test/dired-sidebar-test.el
@@ -104,8 +104,7 @@ already showing."
     (dired-sidebar-hide-sidebar)))
 
 (ert-deftest dired-sidebar-sidebar-killed-sidebar-buffer-in-frame-returns-nil ()
-  "Test that `dired-sidebar-buffer' returns nil
-if the buffer has been killed. Also test alist have been cleaned up."
+  "Test that `dired-sidebar-buffer' returns nil if the buffer has been killed."
   (let* ((default-directory test-data-dir-basic)
          (A-buffer (find-file-noselect
                     (f-join default-directory "A") t)))
@@ -113,10 +112,8 @@ if the buffer has been killed. Also test alist have been cleaned up."
       (call-interactively 'dired-sidebar-toggle-sidebar)
       (let ((sidebar (dired-sidebar-buffer)))
         (should sidebar)
-        (should dired-sidebar-alist)
         (kill-buffer sidebar)
-        (should (not (dired-sidebar-buffer)))
-        (should (not dired-sidebar-alist))))
+        (should (not (dired-sidebar-buffer)))))
     (kill-buffer A-buffer)))
 
 (ert-deftest dired-sidebar-get-file-to-show-returns-nil-for-unsaved-buffers ()


### PR DESCRIPTION
`Cask && make compile && make lint && make test` would fail on multiple errors. 

After the changes here, all three make targets pass.

PS as the travis ci integration seems to be gone, I've created a separate patch that uses GitHub Actions for CI: https://github.com/shayelkin/dired-sidebar/pull/1